### PR TITLE
Update proxies.json

### DIFF
--- a/proxies.json
+++ b/proxies.json
@@ -73,7 +73,7 @@
   },
   {
     "wallet": "CCUWF8sALfvVtv1EvKwuM4p7ZgUWvsrKVzQfFGmBz6pa",
-    "name": "Keith Rettig (KeithR)",
+    "name": "Keith Rettig",
     "image": "./proxies/KeithRettig/image.png",
     "description": "Keith Rettig",
     "detail": "./proxies/KeithRettig/detail.md",


### PR DESCRIPTION
I think the parentheses were causing the name not to be selectable in the proxy list.
[added later]
They don't matter.  What seems to matter is that you can not select all of your positions and then assign a proxy to them.  I can only pick the proxy first and then select all of the positions.